### PR TITLE
Expose swagger UI & descriptor

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,25 +1,266 @@
 # Frequently Asked Questions
 
-## How can my µService be deployed ?
+- [What are deployment modes?](#what-are-deployment-modes)
+- [Can exposed API be asynchronous?](#can-exposed-api-be-asynchronous)
+- [Where to put asynchronous initialization?](#where-to-put-asynchronous-initialization)
+- [Can initialization code be configured?](#can-initialization-code-be-configured)
+- [How can service definition be more modular?](#how-can-service-definition-be-more-modular)
+- [How can initialisation be shared by different groups?](#how-can-initialisation-be-shared-by-different-groups)
+- [How could input parameters be validated?](#how-could-input-parameters-be-validated)
+- [Is Swagger/OpenAPI supported?](#is-swaggeropenapi-supported)
 
-You can use it locally (same node.js instance as the caller code), or remotely (deployed as remote HTTP server).
-Local is the default mode.
+## What are deployment modes?
 
-To use remotely, simply:
+µServices based on mini-service could be deployed either:
+- locally: runs on the same nodejs process as the caller code
+  ```js
+  const {getClient} = require('mini-service')
 
- - call `startServer()` with your service definition (including init function options)
- - from the caller code, provide the Http server url to your client: `const client = require('service')({remote: 'http://my-service:3000')`
+  // define a service
+  const calc = getClient({
+    name: 'calc',
+    version: '1.0.0',
+    init: () => ({
+      add: (a, b) => a + b
+    })
+  })
 
-And that's all !
+  await calc.init()
+
+  // invoke exposed api as async function
+  const sum = await calc.add(10 + 5)
+  ```
+
+- remotely: runs as a dedicated HTTP server
+  ```js
+  // server.js
+  const {startServer} = require('mini-service')
+
+  // define a service, start Http server
+  startServer({
+    name: 'calc',
+    version: '1.0.0',
+    init: () => ({
+      add: (a, b) => a + b
+    })
+  })
+  ```
+
+  ```js
+  // client.js
+  const {getClient} = require('mini-service')
+
+  // will connect to server on demand
+  const calc = getClient({
+    remote: 'http://localhost:3000'
+  })
+
+  // invoke exposed api as async function
+  const sum = await calc.add(10 + 5)
+  ```
+
+No need to add the service code as a dependency when using `getClient()` with remote url/
 
 
-## I'm tired of writing parameters validation logic...
+## Can exposed API be asynchronous?
 
-Because validating (from a syntactic point of view) parameters is so common, mini-service includes a validation feature.
-Each exposed API can be linked to a [Joi](https://github.com/hapijs/joi/blob/master/API.md) validation object.
-This object is an array of *validation schema*, each of them bound to a parameter and specifying parameter syntactic expectations.
+Yes, by using Promises:
 
-```javascript
+```js
+const {startService} = require('mini-service')
+
+startService({
+  name: 'calc',
+  version: '1.0.0',
+  init: () => ({
+    add: (a, b) => a + b,                    // synchronous API,
+    subtract: async (a, b) => a - b          // asynchronous API, async/await syntax
+    divide: (a, b) => Promise.resolve(a / b) // asynchronous API, promise-based
+  })
+})
+```
+
+
+## Where to put asynchronous initialization? (connect to DB, open files...)
+
+To serve this purpose, the `init()` function can be either synchronous or return a Promise.
+
+```js
+const {promisify} = require('util')
+const readFile = promisify(require('readFile').readFile)
+const {startService} = require('mini-service')
+
+startService({
+  name: 'async-init',
+  version: '1.0.0',
+  init: async () => {
+    // let's say we need to read a configuration file...
+    const content = await readFile('whatever.html')
+    return {
+      // exposed API list
+    }
+  }
+})
+```
+
+Rejecting the `init()` promise will prevent server to start.
+
+
+## Can initialization code be configured?
+
+`init()` functions are invoked with a single Object parameter, populated with values from the service descriptor.
+
+```js
+const {promisify} = require('util')
+const readFile = promisify(require('readFile').readFile)
+const {startService} = require('mini-service')
+
+const config = {
+  filePath: 'whatever.html'
+}
+
+startService({
+  name: 'configurable-init'
+  version: '1.0.0',
+  // single parameter is the service definition itself
+  init: async ({filePath}) => {
+    const content = await readFile(filePath)
+    return {
+      // exposed API list
+    }
+  },
+  // all keys in the service definition will be passed to init()
+  ...config
+})
+```
+
+If you use [API groups](#how-can-service-definition-be-more-modular), each group has its own configuration object stored in `groupOpts[group.name]`.
+
+
+## How can service definition be more modular?
+
+Service definition object tend to grow quickly.
+API groups is how mini-service makes the code more modular.
+
+This big service definition:
+
+```js
+const {startService} = require('mini-service')
+
+startService({
+  name: 'monolitic-service',
+  version: '1.0.0',
+  init: () => ({
+    api1: () => {/* ... */},
+    api2: () => {/* ... */},
+    api3: () => {/* ... */},
+    api4: () => {/* ... */},
+    api5: () => {/* ... */}
+  })
+})
+```
+
+can be turned to different groups:
+
+```js
+// server.js
+const {startService} = require('mini-service')
+
+startService({
+  name: 'modular-service',
+  version: '1.0.0',
+  groups: [
+    require('./api/group1'),
+    require('./api/group2')
+  ],
+  groupOpts: {
+    group1: {/* for group 'group1' */},
+    group2: {/* for group 'group2' */}
+  }
+})
+```
+
+```js
+// api/group1.js
+module.exports = {
+  // must be a valid JS identifier
+  name: 'group1',
+  // opts comes from groupOpts[group1]
+  init: opts => ({
+    api1: () => {/* ... */},
+    api2: () => {/* ... */}
+  })
+}
+```
+
+```js
+// api/group2.js
+module.exports = {
+  name: 'group2',
+  // opts comes from groupOpts[group2]
+  init: opts => ({
+    api3: () => {/* ... */},
+    api4: () => {/* ... */},
+    api5: () => {/* ... */}
+  })
+}
+```
+
+Please note that groups are initialized **sequentially**, following the declaration order.
+
+
+## How can initialisation be shared by different groups?
+
+Services are initialized sequentially.
+One can use orderring to perform shared initialization.
+
+
+```js
+// server.js
+const {startService} = require('mini-service')
+
+let shared
+
+startService({
+  name: 'modular-configurable-service',
+  version: '1.0.0',
+  groups: [{
+    name: 'global-init',
+    init: obj => {
+      // initialized shared items
+      shared = { /* ... */ }
+      // doesn't have to expose any API
+    }
+  }, {
+    name: 'group1',
+    // pass your shared object to your init method, as well as other options
+    init: opts => require('./api/group1')(shared, opts)
+  ],
+  groupOpts: {
+    shared: {/* for group 'shared' */}
+    group1: {/* for group 'group1' */}
+  }
+})
+```
+
+```js
+// api/group1.js
+module.exports = (shared, opts) {
+  // initialization code, can use shared items
+  return {/* exposed APIs */}
+}
+```
+
+
+## How could input parameters be validated?
+
+As parameters validation is a common pattern (syntactic validation), mini-service supports it out of the box.
+Parameters of exposed API could be validated with [Joi](https://github.com/hapijs/joi/blob/master/API.md).
+
+Assign an array of *validation schemas* to the `validate` property of an exposed API.
+Each schema will validated a given parameter (order matters).
+
+```js
 const Joi = require('joi')
 const {startService} = require('mini-service')
 
@@ -28,166 +269,61 @@ startService({
   version: '1.0.0',
   init: () => {
     // declare your API
-    const add = (a, b) => Promise.resolve(a + b)
+    const add = (a, b) => a + b
     // attached a schema for each parameter in an array
     add.validate = [
       Joi.Number().required(), // a
-      Joi.Number().required(), // b
+      Joi.Number().required() // b, example used in Swagger documentation
     ]
-
-    return Promise.resolve({add})
+    return {add}
   }
 })
 ```
 
-Prior to any invokation of the API, incoming parameters will be matched against the validation schema, and rejected with
-a 400 error (Bad Request) if they don't comply with expectations.
+Prior to any invokation of the API, incoming parameters will be matched against the validation schema.
+The invokation will fail with a 400 error (Bad Request) if they don't comply.
 
-Tying a schema to an API can be done by assigning a `validate` property the API function, and this schema will only be
-used if the API has at least one parameter.
+## Is Swagger/OpenAPI supported?
 
+Yes, but is disabled by default. It can only be used through `startService()`.
 
-## My service definition isn't really modular...
+To enable and customize it, use `openApi` configuration key.
 
-Your service definition object will probably grow quickly.
-Mini-service offers you an approach to make it more modular: API groups.
-
-You can turn this big service definition:
-
-```javascript
+```js
+const Joi = require('joi')
 const {startService} = require('mini-service')
 
 startService({
-  name: 'my-big-service',
-  version: '10.4.2',
-  init: opts => {
-    // ... initialization code
-    return Promise.resolve({
-      api1: () => {/* ... */},
-      api2: () => {/* ... */},
-      api3: () => {/* ... */},
-      api4: () => {/* ... */},
-      api5: () => {/* ... */},
-      // ...
-    })
-  },
-  // other opts for init()
+  name: 'documented-service',
+  version: '1.0.0',
+  openApi: {
+    // see https://github.com/glennjones/hapi-swagger/blob/master/optionsreference.md
+    info: {
+      title: 'Simple calculator'
+    }
+    /* defaults are:
+    info: {version},
+    documentationPath: '/documentation',
+    jsonPath: '/swagger.json',
+    basePath: '/api',
+    pathPrefixSize: 2
+    */
+  }
+  init: () => {
+    const add = (a, b) => a + b
+
+    // document api
+    add.description = 'Sum numbers'
+    add.notes = 'Only works with two numbers'
+
+    // document parameters
+    add.validate = [
+      Joi.Number().required().description('reference number').example(5),
+      Joi.Number().required().description('added to reference').example(2)
+    ]
+    return {add}
+  }
 })
 ```
 
-To use different groups:
-`server.js`
-```javascript
-const {startService} = require('mini-service')
-
-startService({
-  name: 'my-big-service',
-  version: '10.4.2',
-  groups: [
-    require('api/group1'),
-    require('api/group2')
-  ],
-  groupOpts: {
-    group1: {/* group 1 init options */},
-    group2: {/* group 2 init options */}
-  }
-}
-```
-`api/group1.js`
-```javascript
-module.exports =
-  name: 'group1', // must be a valid JS identifier (for the groupOpts hash)
-  init: opts => {
-    // initialization code, opts is groupOpts.group1
-    return Promise({
-      api1: () => {/* ... */},
-      api2: () => {/* ... */}
-    })
-  }
-}
-```
-
-Please note that groups are initialized **sequentially**, following the declaration order.
-
-
-## My service needs to connect to DB/open some files/use asynchronous initialization code...
-
-The `init()` function is the right place to do that:
-
-```javascript
-const fs = require('readFile')
-
-module.exports = {
-  name: 'calc'
-  init: () => new Promise((resolve, reject) => {
-    // let's say we need to read a configuration file...
-    fs.readFile('config.json', (err, content) => {
-      if (err) return reject(err)
-      // initialization goes on...
-      // when you're ready, resolve the promise with the exposed functions
-      resolve({
-        add: (a, b) => Promise.resolve(a + b)
-        subtract: (a, b) => Promise.resolve(a - b)
-      })
-    })
-  })
-}]
-```
-
-Rejecting the `init()` promise will prevent server to start.
-
-
-## How do I configure my service initialization ?
-
-The `init()` function will be invoked with a single Object parameter, populated with values from the service descriptor.
-
-```javascript
-const fs = require('readFile')
-
-module.exports = [{
-  name: 'calc'
-  // opts is an object
-  init: opts => new Promise((resolve, reject) => {
-    // use file given in options instead of hardcoded the value
-    fs.readFile(opts.config, (err, content) => {
-      if (err) return reject(err)
-      resolve({
-        add: (a, b) => Promise.resolve(a + b)
-        subtract: (a, b) => Promise.resolve(a - b)
-      })
-    })
-  }),
-  // configuration values
-  config: 'config.json'
-}]
-```
-
-If you use API groups, the actual options hash is taken from `groupOpts[group.name]`
-
-If you use the simpler service definition form, options hash is the service definition itself.
-
-
-## How can I share initialisation between different files ?
-
-Services will be initialized serially, so you can use this order to perform general initialization.
-
-```javascript
-// shared object among services
-let sql
-
-module.exports = [{
-  name: 'global-init',
-  init: options => new Promise(resolve => {
-    sql = mysqljs(options)
-    // no need to expose anything
-    resolve()
-  })
-}, {
-  name: 'calc',
-  // pass your shared object to your init method, as well as other options
-  init: opts => require('./calc')(sql, opts)
-}, {
-  name: 'utilities',
-  init: opts => require('./utilities')(sql, opts)
-}]
-```
+See a more [complete example](https://github.com/feugy/mini-service/tree/master/examples/documented-service).

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ startServer({
 ### 3.3.0
 - expose customizable OpenAPI descriptor (disabled by default)
 - allow default values for API parameters
+- allow documentation and validation of API result (disabled by default)
 
 ### 3.2.1
 - disabled low-level socket timeout

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module.exports = {
   name: 'calc-service',
   version: '1.0.0',
   init: () => {
-    // each exposed APIs could also return a promise
+    // each exposed APIs could also return a promise/be async
     add: (a, b) => a + b,
     subtract: (a, b) => a - b
   }
@@ -52,9 +52,9 @@ Then, init it (it's an async operation) and invoke any exposed API you need:
 
 `caller-local.js`
 ```javascript
-calc.init().then(() =>
-  calc.add(10, 5).then(sum => console.log(`Result is: ${sum}`))
-)
+await calc.init()
+const sum = await calc.add(10, 5)
+console.log(`Result is: ${sum}`)
 ```
 
 Now let's imagine you need to deploy your calculator service in a standalone Http server, and invoke it from a remote server.
@@ -65,6 +65,7 @@ To turn your local service into a real server, expose your service definition wi
 const {startServer} = require('mini-service')
 
 module.exports = {...} // same service definition as above
+// starts Http server
 startServer(module.exports)
 ```
 A server is now listening on port 3000.
@@ -73,7 +74,7 @@ And to use it from a remote caller, creates a mini-client giving the proper url:
 
 `caller-remote.js`
 ```javascript
-const getClient = require('mini-client') // same as: `const {getClient} = require('mini-service')`
+const getClient = require('mini-client') // or: const {getClient} = require('mini-service')
 
 const calc = getClient({
   remote: 'http://localhost:3000'
@@ -85,12 +86,10 @@ Usage is exactly the same as previously.
 
 `caller-remote.js`
 ```javascript
-calc.init().then(() =>
-  calc.add(10, 5).then(sum => console.log(`Result is: ${sum}`))
-)
+await calc.init() // no-op, can be skipped
+const sum = await calc.add(10, 5)
+console.log(`Result is: ${sum}`)
 ```
-
-Simplistic, but it fits lots of usecases
 
 
 ## Going further
@@ -161,8 +160,12 @@ startServer({
 
 ## Changelog
 
+### 3.3.0
+- expose customizable OpenAPI descriptor (disabled by default)
+- allow default values for API parameters
+
 ### 3.2.1
-- diabled low-level socket timeout
+- disabled low-level socket timeout
 
 ### 3.2.0
 - Support synchronous `init()` and API functions
@@ -232,6 +235,6 @@ startServer({
 [coveralls-image]: https://img.shields.io/coveralls/feugy/mini-service/master.svg
 [coveralls-url]: https://coveralls.io/r/feugy/mini-service?branch=master
 [api-reference-url]: https://feugy.github.io/mini-service/
-[faq]: https://minigithub.com/feugy/mini-service/tree/master/FAQ.md
+[faq]: https://github.com/feugy/mini-service/tree/master/FAQ.md
 [example]: https://github.com/feugy/mini-service/tree/master/examples
 [mini-client]: https://feugy.github.io/mini-client/

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,7 @@
   name: 'calc-service',
   version: '1.0.0',
   init: () => {
-    // each exposed APIs could also return a promise
+    // each exposed APIs could also return a promise/be async
     add: (a, b) => a + b,
     subtract: (a, b) => a - b
   }
@@ -78,31 +78,31 @@ const calcService = require('./calc-service')
 
 const calc = getClient(calcService)</code></pre><p>Then, init it (it's an async operation) and invoke any exposed API you need:</p>
 <p><code>caller-local.js</code></p>
-<pre class="prettyprint source lang-javascript"><code>calc.init().then(() =>
-  calc.add(10, 5).then(sum => console.log(`Result is: ${sum}`))
-)</code></pre><p>Now let's imagine you need to deploy your calculator service in a standalone Http server, and invoke it from a remote server.
+<pre class="prettyprint source lang-javascript"><code>await calc.init()
+const sum = await calc.add(10, 5)
+console.log(`Result is: ${sum}`)</code></pre><p>Now let's imagine you need to deploy your calculator service in a standalone Http server, and invoke it from a remote server.
 To turn your local service into a real server, expose your service definition with mini-service's <code>startServer()</code>:</p>
 <p><code>calc-service.js</code></p>
 <pre class="prettyprint source lang-javascript"><code>const {startServer} = require('mini-service')
 
 module.exports = {...} // same service definition as above
+// starts Http server
 startServer(module.exports)</code></pre><p>A server is now listening on port 3000.</p>
 <p>And to use it from a remote caller, creates a mini-client giving the proper url:</p>
 <p><code>caller-remote.js</code></p>
-<pre class="prettyprint source lang-javascript"><code>const getClient = require('mini-client') // same as: `const {getClient} = require('mini-service')`
+<pre class="prettyprint source lang-javascript"><code>const getClient = require('mini-client') // or: const {getClient} = require('mini-service')
 
 const calc = getClient({
   remote: 'http://localhost:3000'
 })</code></pre><p>Please note that you <strong>don't need to require the service definition anymore</strong>.</p>
 <p>Usage is exactly the same as previously.</p>
 <p><code>caller-remote.js</code></p>
-<pre class="prettyprint source lang-javascript"><code>calc.init().then(() =>
-  calc.add(10, 5).then(sum => console.log(`Result is: ${sum}`))
-)</code></pre><p>Simplistic, but it fits lots of usecases</p>
-<h2>Going further</h2><p>Please also checkout:</p>
+<pre class="prettyprint source lang-javascript"><code>await calc.init() // no-op, can be skipped
+const sum = await calc.add(10, 5)
+console.log(`Result is: ${sum}`)</code></pre><h2>Going further</h2><p>Please also checkout:</p>
 <ul>
 <li><a href="https://feugy.github.io/mini-service/">API Reference</a></li>
-<li><a href="https://minigithub.com/feugy/mini-service/tree/master/FAQ.md">Frequently asked questions</a></li>
+<li><a href="https://github.com/feugy/mini-service/tree/master/FAQ.md">Frequently asked questions</a></li>
 <li>[Examples][examples]</li>
 </ul>
 <p>FAQ covers topics like modularity, aynsc initialization, parameters validation...</p>
@@ -126,13 +126,28 @@ const calc = getClient({
     ping()
   }
 }</code></pre><h2>1.x to 2.x changes</h2><p>Local services, as remote services, <strong>must</strong> have <code>name</code> and <code>version</code> options defined</p>
-<p>When defining services, the <code>name</code> property was renamed to <code>group</code>:</p>
-<pre class="prettyprint source lang-javascript"><code>module.exports = [{
-  group: 'calc', // was name previously
-  init: () => Promise.resolve({
-    add: (a, b) => ...,
-    subtract: (a, b) => ...
-  })</code></pre><h2>Changelog</h2><h3>3.2.0</h3><ul>
+<p>When loading services, the <code>services</code> property was renamed to <code>groups</code>, and <code>serviceOpts</code> is now <code>groupOpts</code>:</p>
+<pre class="prettyprint source lang-javascript"><code>const {startServer} = require('mini-service')
+
+startServer({
+  groups: [ // was services previously
+    require('../serviceA'),
+    require('../serviceB'),
+    require('../serviceC')
+  ],
+  groupOpts: { // was serviceOpts previously
+    serviceA: {},
+    serviceB: {},
+    serviceC: {}
+  }
+})</code></pre><h2>Changelog</h2><h3>3.3.0</h3><ul>
+<li>expose customizable OpenAPI descriptor</li>
+<li>allow default values for API parameters</li>
+</ul>
+<h3>3.2.1</h3><ul>
+<li>disabled low-level socket timeout</li>
+</ul>
+<h3>3.2.0</h3><ul>
 <li>Support synchronous <code>init()</code> and API functions</li>
 <li>Dependencies update</li>
 </ul>

--- a/docs/module-server.html
+++ b/docs/module-server.html
@@ -86,7 +86,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="server.js.html">server.js</a>, <a href="server.js.html#line132">line 132</a>
+        <a href="server.js.html">server.js</a>, <a href="server.js.html#line186">line 186</a>
     </li></ul></dd>
     
 

--- a/docs/server.js.html
+++ b/docs/server.js.html
@@ -41,15 +41,18 @@
 const joi = require('joi')
 const boom = require('boom')
 const crc32 = require('crc32')
+const {merge} = require('hoek')
 const {
   arrayToObj,
   checksumHeader,
   extractGroups,
+  extractValidate,
   getLogger,
   getParamNames,
-  isApi,
-  validateParams
+  isApi
 } = require('mini-service-utils')
+
+const basePath = '/api'
 
 /**
  * @module server
@@ -116,15 +119,28 @@ const registerAsPlugins = (server, opts, logger) => {
                 for (const id in apis) {
                   const api = apis[id]
                   const params = getParamNames(api)
-                  const path = `/api/${group}/${id}`
-                  const config = {validate: {}}
+                  const path = `${basePath}/${group}/${id}`
+                  const config = {
+                    // disabled default 2 minutes timeout
+                    timeout: {socket: false},
+                    tags: ['api'],
+                    // copy documentation keys, if available, for openapi description
+                    notes: api.notes,
+                    description: api.description
+                  }
+                  const validate = extractValidate(id, apis, groupOpts[group])
                   // adds input validation if needed
-                  if (api.length &amp;&amp; api.validate) {
+                  if (params.length &amp;&amp; validate) {
                     try {
-                      const schema = joi.object(arrayToObj(api.validate, params)).unknown(false)
-                      // use custom validation instead of Joi schema for a better reporting in case of extra parameters
-                      config.validate.payload = (values, validationOpts, done) =>
-                        done(validateParams(values, schema, id, params.length))
+                      config.validate = {
+                        payload: joi.object(arrayToObj(validate, params)).unknown(false).label(id),
+                        failAction: (req, reply, source, error) => {
+                          // customize error message for convenience
+                          error.message = `Incorrect parameters for API ${id}: ${error.message}`
+                          error.reformat()
+                          reply(error)
+                        }
+                      }
                     } catch (exc) {
                       throw new Error(`Invalid validation schema for API ${id} (from group ${group}): ${exc.message}`)
                     }
@@ -133,7 +149,7 @@ const registerAsPlugins = (server, opts, logger) => {
                   exposed.push({group, id, params, path})
                   // publish each API as a POST endpoint
                   serv.route({
-                    method: api.length ? 'POST' : 'GET',
+                    method: params.length ? 'POST' : 'GET',
                     path,
                     config,
                     handler: (req, reply) => {
@@ -167,6 +183,44 @@ const registerAsPlugins = (server, opts, logger) => {
     return Promise.reject(err)
   }
 }
+
+/**
+ * @private
+ * @summary Expose OpenAPI json descriptor and documentation GUI
+ * @description Expose Swagger GUI under `/documentation` and `/swagger.json` file.
+ * All options supported by https://github.com/glennjones/hapi-swagger can be used.
+ * Can only document routes already registered.
+ *
+ * @param {Hapi} server                   for which documentation is created and exposed
+ * @param {Object} opts                   hapi-swagger options, with following defaults:
+ * @param {Object} [opts.info]              global informations, including
+ * @param {String} [opts.info.version]        API version, same as service version
+ * @param {String} [opts.documentationPath] path for GUI, defaults to /documentation
+ * @param {String} [opts.jsonPath]          path for json descriptor, defaults to /swagger.json
+ * @param {String} [opts.basePath]          endpoint base path, defaults to /api
+ * @param {Number} [opts.pathPrefixSize]    number of segment used for grouping, defaults to 2
+ * @param {String} version                server version
+ * @param {Object} logger                 {@link https://github.com/trentm/node-bunyan|bunyan} compatible logger
+ * @returns {Promise} promise             when documentation is ready
+ */
+const exposeDocumentation = (server, opts, version, logger) =>
+  server.register([
+    require('inert'),
+    require('vision'),
+    {
+      register: require('hapi-swagger'),
+      options: merge({
+        info: {version},
+        documentationPath: '/documentation',
+        jsonPath: '/swagger.json',
+        basePath,
+        pathPrefixSize: 2
+      }, opts)
+    }]
+  )
+    .then(res => {
+      logger.info(`OpenAPI documentation available at ${opts.documentationPath} and descriptor at ${opts.jsonPath}`)
+    })
 
 /**
  * @function startServer
@@ -248,13 +302,17 @@ module.exports = (opts = {}) => {
       // list of exposed APIs, for clients
       server.route({
         method: 'GET',
-        path: '/api/exposed',
+        path: `${basePath}/exposed`,
         handler: (req, reply) => reply({
           name,
           version,
           apis
         })
       })
+    })
+    .then(() => {
+      const {openApi, version} = opts
+      return openApi ? exposeDocumentation(server, openApi, version, logger) : Promise.resolve()
     })
     .then(() => server.start())
     .then(() => {

--- a/examples/documented-service/README.md
+++ b/examples/documented-service/README.md
@@ -1,0 +1,12 @@
+# Documentation example
+
+[OpenAPI](https://swagger.io/specification/) (formely known as Swagger) descriptor could be provided automatically.
+An handy GUI is also available.
+
+Disabled by default, provide `swagger` option to service definition to enable it.
+
+To run the example:
+> node documented-service
+
+Then open a browser to http://localhost:3000/documentation
+

--- a/examples/documented-service/documented-service.js
+++ b/examples/documented-service/documented-service.js
@@ -1,0 +1,31 @@
+const {startServer} = require('../../') // require('mini-service')
+
+// service definition: name, version and the exposed APIs
+// export it so you can easilly use it with a local caller
+module.exports = {
+  name: 'documented-service',
+  version: '1.0.0',
+  // enable swagger descriptor, see https://github.com/glennjones/hapi-swagger
+  openApi: {
+    info: {
+      title: 'Documentation example for mini-service',
+      description: 'Provide OpenAPI descriptor and GUI thanks to <a href="https://github.com/glennjones/hapi-swagger">hapi-swagger</a>'
+    },
+    // default to /swagger.json
+    jsonPath: '/openapi.json',
+    // default to /documentation
+    documentationPath: '/doc',
+    // false to only expose swagger.json
+    documentationPage: true,
+    // attach general description to each group
+    tags: [{
+      name: 'users',
+      description: 'Simplistic user repository'
+    }]
+  },
+  groups: [
+    require('./users')
+  ]
+}
+
+startServer(module.exports)

--- a/examples/documented-service/users.js
+++ b/examples/documented-service/users.js
@@ -1,0 +1,56 @@
+const Joi = require('joi')
+
+module.exports = {
+  name: 'users',
+  init: () => {
+    const cache = {}
+
+    const apis = {
+      list: (rank = 0, size = 10) =>
+        Object.keys(cache)
+          .filter((id, i) => i >= rank && i < rank + size)
+          .map(id => cache[id]),
+
+      save: user => {
+        if (!user.id) {
+          user.id = Math.floor(Math.random() * 1000)
+        }
+        cache[user.id] = user
+        return user
+      },
+
+      remove: id => {
+        cache[id] = undefined
+      }
+    }
+
+    apis.list.validate = [
+      Joi.number().min(0).default(0)
+        .description('rank of first returned item'),
+      Joi.number().min(1).default(10)
+        .description('maximal size of returned list')
+    ]
+    apis.list.description = 'Paginated list of cached users.'
+    apis.list.notes = 'Insertion order is used.'
+
+    apis.save.validate = [
+      Joi.object().keys({
+        id: Joi.number()
+          .description('user id, generated if not provided'),
+        name: Joi.string().required()
+          .description('user name').example('Mary')
+      }).required().unknown()
+        .label('User').description('saved user. Will update existing user if id already exists')
+    ]
+    apis.save.description = 'Adds new or updates existing user in cache, based on id.'
+
+    apis.remove.validate = [
+      Joi.number().required()
+        .description('removed user id').example(1)
+    ]
+    apis.remove.description = 'Removes existing user in cache, based on id.'
+    apis.remove.notes = 'Does nothing if id cannot be found.'
+
+    return apis
+  }
+}

--- a/examples/single-file-service/README.md
+++ b/examples/single-file-service/README.md
@@ -15,4 +15,3 @@ To run it as a server, and remote caller:
 
 and in a second terminal
 > node caller-remote
-

--- a/examples/single-file-service/calc-service.js
+++ b/examples/single-file-service/calc-service.js
@@ -5,10 +5,9 @@ const {startServer} = require('../../') // require('mini-service')
 module.exports = {
   name: 'calc-service',
   version: '1.0.0',
-  init: () => Promise.resolve({
-    // each exposed APIs must return a promise
-    add: (a, b) => Promise.resolve(a + b),
-    subtract: (a, b) => Promise.resolve(a - b)
+  init: () => ({
+    add: (a, b) => a + b,
+    subtract: (a, b) => a - b
   })
 }
 

--- a/examples/single-file-service/caller-local.js
+++ b/examples/single-file-service/caller-local.js
@@ -4,7 +4,11 @@ const calcService = require('./calc-service')
 // local client needs service definition
 const calc = getClient(calcService)
 
-// after a mandatory initialisation, you can call any exposed API
-calc.init().then(() =>
-  calc.add(10, 5).then(sum => console.log(`Result is: ${sum}`))
-)
+// async wrapper, only required in global scope
+async function main () {
+  // after a mandatory initialisation, you can call any exposed API
+  await calc.init()
+  console.log(`Result is: ${await calc.add(10, 5)}`)
+}
+
+main()

--- a/examples/single-file-service/caller-remote.js
+++ b/examples/single-file-service/caller-remote.js
@@ -5,8 +5,11 @@ const calc = getClient({
   remote: 'http://localhost:3000'
 })
 
-// initialisation isn't strictly required (it will be done at first call), but consistent with local pattern
-calc.init().then(() =>
-  // then you can call any exposed API
-  calc.add(10, 5).then(sum => console.log(`Result is: ${sum}`))
-)
+// async wrapper, only required in global scope
+async function main () {
+  // initialisation isn't strictly required (it will be done at first call), but consistent with local mode
+  // await calc.init()
+  console.log(`Result is: ${await calc.add(10, 5)}`)
+}
+
+main()

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,15 +2,18 @@ const {Server} = require('hapi')
 const joi = require('joi')
 const boom = require('boom')
 const crc32 = require('crc32')
+const {merge} = require('hoek')
 const {
   arrayToObj,
   checksumHeader,
   extractGroups,
+  extractValidate,
   getLogger,
   getParamNames,
-  isApi,
-  validateParams
+  isApi
 } = require('mini-service-utils')
+
+const basePath = '/api'
 
 /**
  * @module server
@@ -77,19 +80,28 @@ const registerAsPlugins = (server, opts, logger) => {
                 for (const id in apis) {
                   const api = apis[id]
                   const params = getParamNames(api)
-                  const path = `/api/${group}/${id}`
+                  const path = `${basePath}/${group}/${id}`
                   const config = {
                     // disabled default 2 minutes timeout
                     timeout: {socket: false},
-                    validate: {}
+                    tags: ['api'],
+                    // copy documentation keys, if available, for openapi description
+                    notes: api.notes,
+                    description: api.description
                   }
+                  const validate = extractValidate(id, apis, groupOpts[group])
                   // adds input validation if needed
-                  if (api.length && api.validate) {
+                  if (params.length && validate) {
                     try {
-                      const schema = joi.object(arrayToObj(api.validate, params)).unknown(false)
-                      // use custom validation instead of Joi schema for a better reporting in case of extra parameters
-                      config.validate.payload = (values, validationOpts, done) =>
-                        done(validateParams(values, schema, id, params.length))
+                      config.validate = {
+                        payload: joi.object(arrayToObj(validate, params)).unknown(false).label(id),
+                        failAction: (req, reply, source, error) => {
+                          // customize error message for convenience
+                          error.message = `Incorrect parameters for API ${id}: ${error.message}`
+                          error.reformat()
+                          reply(error)
+                        }
+                      }
                     } catch (exc) {
                       throw new Error(`Invalid validation schema for API ${id} (from group ${group}): ${exc.message}`)
                     }
@@ -98,7 +110,7 @@ const registerAsPlugins = (server, opts, logger) => {
                   exposed.push({group, id, params, path})
                   // publish each API as a POST endpoint
                   serv.route({
-                    method: api.length ? 'POST' : 'GET',
+                    method: params.length ? 'POST' : 'GET',
                     path,
                     config,
                     handler: (req, reply) => {
@@ -132,6 +144,44 @@ const registerAsPlugins = (server, opts, logger) => {
     return Promise.reject(err)
   }
 }
+
+/**
+ * @private
+ * @summary Expose OpenAPI json descriptor and documentation GUI
+ * @description Expose Swagger GUI under `/documentation` and `/swagger.json` file.
+ * All options supported by https://github.com/glennjones/hapi-swagger can be used.
+ * Can only document routes already registered.
+ *
+ * @param {Hapi} server                   for which documentation is created and exposed
+ * @param {Object} opts                   hapi-swagger options, with following defaults:
+ * @param {Object} [opts.info]              global informations, including
+ * @param {String} [opts.info.version]        API version, same as service version
+ * @param {String} [opts.documentationPath] path for GUI, defaults to /documentation
+ * @param {String} [opts.jsonPath]          path for json descriptor, defaults to /swagger.json
+ * @param {String} [opts.basePath]          endpoint base path, defaults to /api
+ * @param {Number} [opts.pathPrefixSize]    number of segment used for grouping, defaults to 2
+ * @param {String} version                server version
+ * @param {Object} logger                 {@link https://github.com/trentm/node-bunyan|bunyan} compatible logger
+ * @returns {Promise} promise             when documentation is ready
+ */
+const exposeDocumentation = (server, opts, version, logger) =>
+  server.register([
+    require('inert'),
+    require('vision'),
+    {
+      register: require('hapi-swagger'),
+      options: merge({
+        info: {version},
+        documentationPath: '/documentation',
+        jsonPath: '/swagger.json',
+        basePath,
+        pathPrefixSize: 2
+      }, opts)
+    }]
+  )
+    .then(res => {
+      logger.info(`OpenAPI documentation available at ${opts.documentationPath} and descriptor at ${opts.jsonPath}`)
+    })
 
 /**
  * @function startServer
@@ -213,13 +263,17 @@ module.exports = (opts = {}) => {
       // list of exposed APIs, for clients
       server.route({
         method: 'GET',
-        path: '/api/exposed',
+        path: `${basePath}/exposed`,
         handler: (req, reply) => reply({
           name,
           version,
           apis
         })
       })
+    })
+    .then(() => {
+      const {openApi, version} = opts
+      return openApi ? exposeDocumentation(server, openApi, version, logger) : Promise.resolve()
     })
     .then(() => server.start())
     .then(() => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,7 @@ const {merge} = require('hoek')
 const {
   arrayToObj,
   checksumHeader,
+  enrichError,
   extractGroups,
   extractValidate,
   getLogger,
@@ -89,21 +90,28 @@ const registerAsPlugins = (server, opts, logger) => {
                     notes: api.notes,
                     description: api.description
                   }
-                  const validate = extractValidate(id, apis, groupOpts[group])
                   // adds input validation if needed
-                  if (params.length && validate) {
+                  const payloadSchema = extractValidate(id, apis, groupOpts[group], 'validate')
+                  if (params.length && payloadSchema) {
                     try {
                       config.validate = {
-                        payload: joi.object(arrayToObj(validate, params)).unknown(false).label(id),
-                        failAction: (req, reply, source, error) => {
-                          // customize error message for convenience
-                          error.message = `Incorrect parameters for API ${id}: ${error.message}`
-                          error.reformat()
-                          reply(error)
-                        }
+                        payload: joi.object(arrayToObj(payloadSchema, params)).unknown(false).label(id),
+                        // customize error message for convenience
+                        failAction: (req, reply, source, error) => reply(enrichError(error, id))
                       }
                     } catch (exc) {
                       throw new Error(`Invalid validation schema for API ${id} (from group ${group}): ${exc.message}`)
+                    }
+                  }
+                  // adds response validation if needed
+                  const responseSchema = extractValidate(id, apis, groupOpts[group], 'responseSchema')
+                  if (responseSchema) {
+                    config.response = {
+                      schema: responseSchema.label(`${id}Result`),
+                      // customize error message for convenience
+                      failAction: (req, reply, error) => reply(enrichError(error, id, false)),
+                      // only apply response validation if explicitly needed
+                      sample: api.validateResponse ? 100 : 0
                     }
                   }
                   // keep the list of exposed functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-service",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Micro services done simply. Choose to run them locally or remotely",
   "author": "feugy <damien.feugas@gmail.com>",
   "license": "MIT",
@@ -24,9 +24,13 @@
     "boom": "~6.0.0",
     "crc32": "~0.2.2",
     "hapi": "~16.6.2",
+    "hapi-swagger": "~7.9.1",
+    "hoek": "~5.0.2",
+    "inert": "~4.2.1",
     "joi": "~11.1.1",
     "mini-client": "~3.2.0",
-    "mini-service-utils": "~2.3.0"
+    "mini-service-utils": "~2.3.0",
+    "vision": "~4.1.1"
   },
   "devDependencies": {
     "benchmark": "~2.1.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "inert": "~4.2.1",
     "joi": "~11.1.1",
     "mini-client": "~3.2.0",
-    "mini-service-utils": "~2.3.0",
+    "mini-service-utils": "~2.4.0",
     "vision": "~4.1.1"
   },
   "devDependencies": {

--- a/test/fixtures/sample.js
+++ b/test/fixtures/sample.js
@@ -6,31 +6,35 @@ const {unauthorized} = require('boom')
  * @param {Object} opts service opts
  * @returns {Promise} resolve with an object containing exposed APIs
  */
-module.exports = (opts = {}) => {
+module.exports = async (opts = {}) => {
   const apis = {
     /**
      * Respond to ping
      * @returns {Promise<Object>} resolved with an object containing current time
      */
-    ping () {
-      return Promise.resolve({time: new Date()})
+    async ping () {
+      return {time: new Date()}
     },
 
     /**
-     * Kindly say hello, and demonstrate how to validate input parameters
+     * Kindly say hello, and demonstrate how to validate input parameters and response
      * @param {String} name person to greet
-     * @returns {Promise} resolved with a greeting string message
+     * @returns {Promise} resolved with a greeting string message, null if name is 'boom'
      */
-    greeting (name) {
-      return Promise.resolve(`Hello ${name}${opts.greetings || ''} !`)
+    async greeting (name) {
+      if (name === 'boom') {
+        // will trigger response validation error
+        return null
+      }
+      return `Hello ${name}${opts.greetings || ''} !`
     },
 
     /**
      * Failing API to test rejection handling
      * @returns {Promise} always rejected
      */
-    failing () {
-      return Promise.reject(new Error('something went really bad'))
+    async failing () {
+      throw new Error('something went really bad')
     },
 
     /**
@@ -45,21 +49,28 @@ module.exports = (opts = {}) => {
      * API that returns undefined
      * @returns {Promise} always resolved with undefined
      */
-    getUndefined () {
-      return Promise.resolve(undefined)
+    async getUndefined () {
+      return undefined
     },
 
     /**
      * API that generates a 401 Boom error
      * @returns {Promise} rejected with Unauthorized Boom error with custom message
      */
-    boomError () {
-      return Promise.reject(unauthorized('Custom authorization error'))
+    async boomError () {
+      throw unauthorized('Custom authorization error')
     }
   }
+
+  // adds output documentation
+  apis.ping.responseSchema = Joi.date().required()
 
   // adds input validation
   apis.greeting.validate = [Joi.string().required()]
 
-  return Promise.resolve(apis)
+  // adds output documentation & validation
+  apis.greeting.responseSchema = Joi.string().required()
+  apis.greeting.validateResponse = true
+
+  return apis
 }

--- a/test/fixtures/synchronous.js
+++ b/test/fixtures/synchronous.js
@@ -9,11 +9,15 @@ const {unauthorized} = require('boom')
 module.exports = (opts = {}) => {
   const apis = {
     /**
-     * Kindly say hello, and demonstrate how to validate input parameters
+     * Kindly say hello, and demonstrate how to validate input parameters and response
      * @param {String} name person to greet
-     * @returns {String} greeting string message
+     * @returns {String} greeting string message, null if name is 'boom'
      */
     greeting (name) {
+      if (name === 'boom') {
+        // will trigger response validation error
+        return null
+      }
       return `Hello ${name}${opts.greetings || ''} !`
     },
 
@@ -27,15 +31,19 @@ module.exports = (opts = {}) => {
 
     /**
      * API that generates a 401 Boom error
-     * @returns {Error} Unauthorized Boom error with custom message
+     * @throws {Error} Unauthorized Boom error with custom message
      */
     boomError () {
-      return unauthorized('Custom authorization error')
+      throw unauthorized('Custom authorization error')
     }
   }
 
   // adds input validation
   apis.greeting.validate = [Joi.string().required()]
+
+  // adds output documentation & validation
+  apis.greeting.responseSchema = Joi.string().required()
+  apis.greeting.validateResponse = true
 
   return apis
 }

--- a/test/server.js
+++ b/test/server.js
@@ -107,7 +107,7 @@ describe('service\'s server', () => {
     const checksum = crc32(JSON.stringify(exposedApis))
 
     before(() =>
-      startServer({name, version, groups}).then(s => {
+      startServer({name, version, groups, openApi: {}}).then(s => {
         server = s
       })
     )
@@ -128,6 +128,27 @@ describe('service\'s server', () => {
           version,
           apis: exposedApis
         })
+      })
+    )
+
+    it('should expose documentation', () =>
+      request({
+        method: 'GET',
+        url: `${server.info.uri}/documentation`
+      }).then(content => {
+        assert(content.includes('/swaggerui/swagger-ui.js'))
+      })
+    )
+
+    it('should expose openapi descriptor', () =>
+      request({
+        method: 'GET',
+        url: `${server.info.uri}/swagger.json`,
+        json: true
+      }).then(descriptor => {
+        assert(descriptor.swagger === '2.0')
+        assert(descriptor.basePath === '/api')
+        assert.deepStrictEqual(descriptor.info, {title: 'API documentation', version})
       })
     )
 
@@ -201,7 +222,7 @@ describe('service\'s server', () => {
         assert(error.statusCode === 400)
         return request({
           method: 'POST',
-          url: `${server.info.uri}/api/sample/greeting`,
+          url: `${server.info.uri}/api/synchronous/greeting`,
           body: {
             name: 10
           },
@@ -225,7 +246,7 @@ describe('service\'s server', () => {
         assert(result === undefined)
         return request({
           method: 'GET',
-          url: `${server.info.uri}/api/sample/getUndefined`,
+          url: `${server.info.uri}/api/synchronous/getUndefined`,
           json: true
         })
       }).then(result => {
@@ -273,7 +294,7 @@ describe('service\'s server', () => {
         assert(err.message.includes('Custom authorization error'))
         return request({
           method: 'GET',
-          url: `${server.info.uri}/api/sample/boomError`
+          url: `${server.info.uri}/api/synchronous/boomError`
         })
       }).then(() => {
         throw new Error('should have failed')


### PR DESCRIPTION
- Thanks to hapi-swagger, exposes an openAPI json descriptor, and GUI. Disabled by default.
- Supports API with parameter default values.
- By setting responseSchema and validateResponse of an expose API, allows to respectively document and validate results.