### PR TITLE
Request payload size limit configure to 1GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 # Changelog
 
+## 3.3.1
+- fix max request payload limit by configuring it to a GB.
 - dependencies update
 
 ## 3.3.0

--- a/lib/server.js
+++ b/lib/server.js
@@ -102,6 +102,11 @@ const registerAsPlugins = (server, opts, logger) => {
                     } catch (exc) {
                       throw new Error(`Invalid validation schema for API ${id} (from group ${group}): ${exc.message}`)
                     }
+                    // disabled payload timeout and set 1Gb max size
+                    config.payload = {
+                      timeout: false,
+                      maxBytes: 1024 * 1024 * 1024
+                    }
                   }
                   // adds response validation if needed
                   const responseSchema = extractValidate(id, apis, groupOpts[group], 'responseSchema')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-service",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Micro services done simply. Choose to run them locally or remotely",
   "author": "feugy <damien.feugas@gmail.com>",
   "license": "MIT",

--- a/test/server.js
+++ b/test/server.js
@@ -351,6 +351,17 @@ describe('service\'s server', () => {
       }
       throw new Error('should have failed')
     })
+
+    it('should not complain about big payload', {timeout: 5e3}, async () => {
+      const name = Array.from({length: 1024 * 1024 * 10}, () => 'a').join('')
+      const greetings = await request({
+        method: 'POST',
+        url: `${server.info.uri}/api/sample/greeting`,
+        body: {name},
+        json: true
+      })
+      assert(greetings)
+    })
   })
 
   describe('server with an ordered list of groups', () => {


### PR DESCRIPTION
Don't reject big incoming request with413 (request entity too large) status code. Previous liimt was 1MB, now configure to 1 GB (such big payload would be unusable in V8 any way).